### PR TITLE
fix: use baud_BS and baud_IT for different gateway types

### DIFF
--- a/pyBrematic/gateways/brennenstuhl_gateway.py
+++ b/pyBrematic/gateways/brennenstuhl_gateway.py
@@ -18,9 +18,9 @@ class BrennenstuhlGateway(Gateway):
         self.tail_format = "{0},{1};"
 
     def build_udp_payload(self, device, action):
-        head = self.get_head(device.repeat, device.pause_BS, device.tune, device.baud)
+        head = self.get_head(device.repeat, device.pause_BS, device.tune, device.baud_BS)
         tail = self.get_tail(device.txversion, device.speed_BS)
-        payload = device.get_signal(self, action)
+        payload = device.get_signal(action)
 
         return ",".join([head, payload, tail])
 

--- a/pyBrematic/gateways/intertechno_gateway.py
+++ b/pyBrematic/gateways/intertechno_gateway.py
@@ -18,9 +18,9 @@ class IntertechnoGateway(Gateway):
         self.tail_format = "{0},{1}"
 
     def build_udp_payload(self, device, action):
-        head = self.get_head(device.repeat, device.pause_IT, device.tune, device.baud)
+        head = self.get_head(device.repeat, device.pause_IT, device.tune, device.baud_IT)
         tail = self.get_tail(device.txversion, device.speed_IT)
-        payload = device.get_signal(self, action)
+        payload = device.get_signal(action)
 
         return ",".join([head, payload, tail])
 

--- a/pyBrematic/gateways/tests/brennenstuhl_gateway_test.py
+++ b/pyBrematic/gateways/tests/brennenstuhl_gateway_test.py
@@ -25,16 +25,18 @@ class TestBrennenstuhlGateway(unittest.TestCase):
         device.repeat = 123
         device.pause_BS = 987
         device.tune = 567
-        device.baud = 999
+        device.baud_BS = 999
         device.txversion = 1
         device.speed_BS = 234
 
-        function = Mock()
-        function.return_value = "SIGNAL-A,B,B,A-SIGNAL"
-        device.get_signal = function
+        get_signal_mock = Mock()
+        get_signal_mock.return_value = "SIGNAL-A,B,B,A-SIGNAL"
+        device.get_signal = get_signal_mock
 
         payload = self.gw.build_udp_payload(device, Action.ON)
         self.assertEqual("TXP:0,0,123,987,567,999,SIGNAL-A,B,B,A-SIGNAL,1,234;", payload)
+        get_signal_mock.assert_called_once_with(Action.ON)
+
 
     def test_get_head(self):
         """Test if formatting the 'head' string works with random data"""

--- a/pyBrematic/gateways/tests/connair_gateway_test.py
+++ b/pyBrematic/gateways/tests/connair_gateway_test.py
@@ -25,16 +25,17 @@ class TestConnAirGateway(unittest.TestCase):
         device.repeat = 2345
         device.pause_BS = 917
         device.tune = 557
-        device.baud = 91919
+        device.baud_BS = 91919
         device.txversion = 1
         device.speed_BS = 234
 
-        function = Mock()
-        function.return_value = "A,SIGNAL-A,B,B,A-SIGNAL,C"
-        device.get_signal = function
+        get_signal_mock = Mock()
+        get_signal_mock.return_value = "A,SIGNAL-A,B,B,A-SIGNAL,C"
+        device.get_signal = get_signal_mock
 
         payload = self.gw.build_udp_payload(device, Action.ON)
         self.assertEqual("TXP:0,0,2345,917,557,91919,A,SIGNAL-A,B,B,A-SIGNAL,C,1,234;", payload)
+        get_signal_mock.assert_called_once_with(Action.ON)
 
     def test_get_head(self):
         """Test if formatting the 'head' string works with random data"""

--- a/pyBrematic/gateways/tests/intertechno_gateway_test.py
+++ b/pyBrematic/gateways/tests/intertechno_gateway_test.py
@@ -26,17 +26,18 @@ class TestIntertechnoGateway(unittest.TestCase):
         device.pause_BS = 917
         device.pause_IT = 111
         device.tune = 557
-        device.baud = 91919
+        device.baud_IT = 91919
         device.txversion = 1
         device.speed_BS = 234
         device.speed_IT = 432
 
-        function = Mock()
-        function.return_value = "A,SIGNAL-A,B,B,A-SIGNAL,C"
-        device.get_signal = function
+        get_signal_mock = Mock()
+        get_signal_mock.return_value = "A,SIGNAL-A,B,B,A-SIGNAL,C"
+        device.get_signal = get_signal_mock
 
         payload = self.gw.build_udp_payload(device, Action.ON)
         self.assertEqual("0,0,2345,111,557,91919,A,SIGNAL-A,B,B,A-SIGNAL,C,1,432", payload)
+        get_signal_mock.assert_called_once_with(Action.ON)
 
     def test_get_head(self):
         """Test if formatting the 'head' string works with random data"""


### PR DESCRIPTION
I totally forgot to use the device specific baud types. Adjusted/added tests as well. I forgot to add test where "get_signal_mock" gets called. This is there now and should work fine.
fixes #21
