### PR TITLE
intertechno: Fix head and tail formatter

### DIFF
--- a/pyBrematic/gateways/intertechno_gateway.py
+++ b/pyBrematic/gateways/intertechno_gateway.py
@@ -14,8 +14,8 @@ class IntertechnoGateway(Gateway):
         # For the Intertechno GWY 433 the parameters look like that:
         # head: "0,0,<repeat>,<pause>,<tune>,<baud>"
         # tail: "<txversion>,<speed>"
-        self.head_format = "0,0,{0},{1},{2},{3}"
-        self.tail_format = "{0},{1}"
+        self.head_format = "0,0,{0},{1},{2},{3},0"
+        self.tail_format = "{0},{1},0"
 
     def build_udp_payload(self, device, action):
         head = self.get_head(device.repeat, device.pause_IT, device.tune, device.baud_IT)

--- a/pyBrematic/gateways/tests/intertechno_gateway_test.py
+++ b/pyBrematic/gateways/tests/intertechno_gateway_test.py
@@ -36,7 +36,7 @@ class TestIntertechnoGateway(unittest.TestCase):
         device.get_signal = get_signal_mock
 
         payload = self.gw.build_udp_payload(device, Action.ON)
-        self.assertEqual("0,0,2345,111,557,91919,A,SIGNAL-A,B,B,A-SIGNAL,C,1,432", payload)
+        self.assertEqual("0,0,2345,111,557,91919,0,A,SIGNAL-A,B,B,A-SIGNAL,C,1,432,0", payload)
         get_signal_mock.assert_called_once_with(Action.ON)
 
     def test_get_head(self):


### PR DESCRIPTION
The head and tail formatter for the Intertechno gateway were missing a trailing "0". After adding these, the ITGW-433 can operate a CMR1000.

The corresponding work can be found here:
https://www.instructables.com/Intertechno-LAN-Gateway-ITGW-433-and-OpenHAB/

Fixes #29 